### PR TITLE
Support Aria Attributes

### DIFF
--- a/app/assets/javascripts/wymeditor/validators.js.erb
+++ b/app/assets/javascripts/wymeditor/validators.js.erb
@@ -26,7 +26,8 @@ WYMeditor.XhtmlValidator = {
       "accesskey",
       "tabindex",
       "data",
-      "^data-.*"
+      "^data-.*",
+      "^aria-.*"
       ]
     },
     "language":


### PR DESCRIPTION
This adds aria-* to validator.js so it will allow aria attributes without any additional configuration. 
